### PR TITLE
SpecialDiffCompare: Use OOUI buttons

### DIFF
--- a/SpecialDiffCompare.php
+++ b/SpecialDiffCompare.php
@@ -78,19 +78,19 @@ class SpecialDiffCompare extends SpecialPage {
 
 		$this->getOutput()->enableOOUI();
 
-		$buttonLeft = new OOUI\ButtonWidget( [
+		$buttonLeft = new \OOUI\ButtonWidget( [
 			'href' => "{$voteUrl}&choice={$method1}",
 			'label' => '< Left diff is better',
 		] );
-		$buttonSame = new OOUI\ButtonWidget( [
+		$buttonSame = new \OOUI\ButtonWidget( [
 			'href' => "{$voteUrl}&choice=none",
 			'label' => 'Both are equally good/bad',
 		] );
-		$buttonRight = new OOUI\ButtonWidget( [
+		$buttonRight = new \OOUI\ButtonWidget( [
 			'href' => "{$voteUrl}&choice={$method2}",
 			'label' => 'Right diff is better >',
 		] );
-		$buttonSkip = new OOUI\ButtonWidget( [
+		$buttonSkip = new \OOUI\ButtonWidget( [
 			'href' => $nextUrl,
 			'label' => 'I abstain',
 		] );

--- a/SpecialDiffCompare.php
+++ b/SpecialDiffCompare.php
@@ -76,16 +76,35 @@ class SpecialDiffCompare extends SpecialPage {
 		$nextUrl = htmlspecialchars( $this->getPageTitle( 'next' )->getLocalURL() );
 		$diffOfDiffs = $this->compareDiffs( $text1, $text2 );
 
+		$this->getOutput()->enableOOUI();
+
+		$buttonLeft = new OOUI\ButtonWidget( [
+			'href' => "{$voteUrl}&choice={$method1}",
+			'label' => '< Left diff is better',
+		] );
+		$buttonSame = new OOUI\ButtonWidget( [
+			'href' => "{$voteUrl}&choice=none",
+			'label' => 'Both are equally good/bad',
+		] );
+		$buttonRight = new OOUI\ButtonWidget( [
+			'href' => "{$voteUrl}&choice={$method2}",
+			'label' => 'Right diff is better >',
+		] );
+		$buttonSkip = new OOUI\ButtonWidget( [
+			'href' => $nextUrl,
+			'label' => 'I abstain',
+		] );
+
 		$html = <<<HTML
 (Links to <a href="https://en.wikipedia.org/w/index.php?oldid=$oldid">old revision</a>, <a href="https://en.wikipedia.org/w/index.php?oldid=$newid">new revision</a>)
 <table style="width: 100%; text-align: center;">
 <tr>
-<td style="width: 33%"><button><a class="votelink" href="{$voteUrl}&amp;choice={$method1}">&lt; Left diff is better</a></button></td>
+<td style="width: 33%">$buttonLeft</td>
 <td style="width: 34%">
-	<button><a class="votelink" href="{$voteUrl}&amp;choice=none">Both are equally good/bad</a></button>
-	<button><a class="votelink" href="{$nextUrl}">I abstain</a></button>
+	$buttonSame
+	$buttonSkip
 </td>
-<td style="width: 33%"><button><a class="votelink" href="{$voteUrl}&amp;choice={$method2}">Right diff is better &gt;</a></button></td>
+<td style="width: 33%">$buttonRight</td>
 </tr>
 </table>
 

--- a/SpecialDiffCompare.php
+++ b/SpecialDiffCompare.php
@@ -72,8 +72,8 @@ class SpecialDiffCompare extends SpecialPage {
 
 		$votePage = $this->getPageTitle( 'vote' );
 		$voteParams = [ 'oldid' => $oldid, 'newid' => $newid ];
-		$voteUrl = htmlspecialchars( $votePage->getLocalURL( $voteParams ) );
-		$nextUrl = htmlspecialchars( $this->getPageTitle( 'next' )->getLocalURL() );
+		$voteUrl = $votePage->getLocalURL( $voteParams );
+		$nextUrl = $this->getPageTitle( 'next' )->getLocalURL();
 		$diffOfDiffs = $this->compareDiffs( $text1, $text2 );
 
 		$this->getOutput()->enableOOUI();


### PR DESCRIPTION
So, you want to make a simple link, but make it look like a button? OOjs UI to the rescue!

Nesting `<a>` inside `<button>` is probably invalid HTML. (And if it isn't, it should be.) The link doesn't work at least in Opera 12 and IE 8.
